### PR TITLE
[Fix] Section2 X-scroll issue

### DIFF
--- a/src/Components/Section2/Section2.js
+++ b/src/Components/Section2/Section2.js
@@ -24,7 +24,7 @@ const Section2 = () => {
           </S.SubTitle>
         </S.TitleSection>
         <S.ImgSection>
-          <Fade right>
+          <Fade top>
             <img src={Alert} className="Alert" alt="Alert-Ui-Img" />
             <img src={SomeDay} className="SomeDay" alt="SomeDay-Ui-Img" />
             <S.AlertImgSection>


### PR DESCRIPTION
Section2의 `AlertImgSection`에 적용된 **Fade animation** 때문에
Fade가 작동되는 동안 **X축이 생겨버리는 이슈**를 발견하여,
기존 `X축 Fade`에서 `Y축 Fade`로 변경하여 이슈를 **해결**해두었습니다.